### PR TITLE
added direction and glowing mode to esp

### DIFF
--- a/src/main/java/com/gamesense/api/util/render/GameSenseTessellator.java
+++ b/src/main/java/com/gamesense/api/util/render/GameSenseTessellator.java
@@ -121,6 +121,98 @@ public class GameSenseTessellator {
 		drawBoundingBoxWithSides(getBoundingBox(blockPos, 1, 1, 1), width, color, sides);
 	}
 
+	/* drawBoxWithDirection start */
+
+	// Children of points, it just contains the 2 coordinates x and y
+	public static class PointDouble {
+		public double x;
+		public double z;
+		public PointDouble(double x, double z) {
+			this.x = x;
+			this.z = z;
+		}
+	}
+	// This contain and elaborate the coordinates
+	public static class Points {
+		// Coordinates
+		private final PointDouble[] point = new PointDouble[4];
+		// For counting when adding to point
+		private int count = 0;
+		// Center of the 2d square
+		private final double xCenter;
+		private final double zCenter;
+		// Feet and Head
+		public final double yMin;
+		public final double yMax;
+		// Rotation
+		private final float rotation;
+		// Constructor
+		public Points(double yMin, double yMax, double xCenter, double zCenter, float rotation) {
+			this.yMin = yMin;
+			this.yMax = yMax;
+			this.xCenter = xCenter;
+			this.zCenter = zCenter;
+			this.rotation = rotation;
+		}
+		// This add and elaborate the points
+		public void addPoints(double x, double z) {
+			/// Creating the rotation
+			// Make center = 0
+			x -= xCenter;
+			z -= zCenter;
+			// Matrix Rotation (https://en.wikipedia.org/wiki/Rotation_matrix)
+			double rotateX = x * Math.cos(rotation) - z * Math.sin(rotation);
+			double rotateZ = x * Math.sin(rotation) + z * Math.cos(rotation);
+			// Return to where we were
+			rotateX += xCenter;
+			rotateZ += zCenter;
+			// Add the point
+			point[count++] = new PointDouble(rotateX, rotateZ);
+		}
+		// Shorter way for getting a point
+		public PointDouble getPoint(int index) {
+			return point[index];
+		}
+
+	}
+
+	public static void drawBoxWithDirection(AxisAlignedBB bb, GSColor color, float rotation) {
+		// Get the center of the 2d square (we are going to rotate based from the cetner)
+		double xCenter = bb.minX + (bb.maxX - bb.minX) / 2;
+		double zCenter = bb.minZ + (bb.maxZ - bb.minZ) / 2;
+		// Collect every points
+		Points square = new Points(bb.minY, bb.maxY, xCenter, zCenter, rotation);
+		// Create every points
+		square.addPoints(bb.minX, bb.minZ);
+		square.addPoints(bb.minX, bb.maxZ);
+		square.addPoints(bb.maxX, bb.maxZ);
+		square.addPoints(bb.maxX, bb.minZ);
+		/// Lets dreaw all the lines
+		// Down
+		for(int i = 0; i < 4; i++) {
+			drawLine(square.getPoint(i).x, square.yMin, square.getPoint(i).z,
+					square.getPoint((i + 1) % 4).x, square.yMin, square.getPoint((i + 1) % 4).z,
+					color
+			);
+		}
+		// Up
+		for(int i = 0; i < 4; i++) {
+			drawLine(square.getPoint(i).x, square.yMax, square.getPoint(i).z,
+					square.getPoint((i + 1) % 4).x, square.yMax, square.getPoint((i + 1) % 4).z,
+					color
+			);
+		}
+		// Vertically
+		for(int i = 0; i < 4; i++) {
+			drawLine(square.getPoint(i).x, square.yMin, square.getPoint(i).z,
+					square.getPoint(i).x, square.yMax, square.getPoint(i).z,
+					color
+			);
+		}
+	}
+
+	/* drawBoxWithDirection end */
+
 	//hoosiers put this together with blood, sweat, and tears D:
 	public static void drawBoundingBoxWithSides(AxisAlignedBB axisAlignedBB, int width, GSColor color, int sides) {
 		Tessellator tessellator = Tessellator.getInstance();

--- a/src/main/java/com/gamesense/client/module/modules/render/ESP.java
+++ b/src/main/java/com/gamesense/client/module/modules/render/ESP.java
@@ -30,11 +30,13 @@ public class ESP extends Module {
     }
 
     Setting.Boolean playerRender;
+    Setting.Boolean playerDirection;
     Setting.Boolean mobRender;
     Setting.Boolean containerRender;
     Setting.Boolean itemRender;
     Setting.Boolean entityRender;
     Setting.Boolean glowCrystals;
+    Setting.Boolean glowPlayer;
     Setting.Integer width;
     Setting.Integer range;
     Setting.ColorSetting mainColor;
@@ -44,11 +46,13 @@ public class ESP extends Module {
         range = registerInteger("Range", "Range", 100, 10, 260);
         width = registerInteger("Line Width", "LineWidth", 2, 1, 5);
         playerRender = registerBoolean("Player", "Player", true);
+        playerDirection = registerBoolean("Direction", "Direction", false);
         mobRender = registerBoolean("Mob", "Mob", false);
         entityRender = registerBoolean("Entity", "Entity", false);
         itemRender = registerBoolean("Item", "Item", true);
         containerRender = registerBoolean("Container", "Container", false);
         glowCrystals = registerBoolean("Glow Crystal", "GlowCrystal", false);
+        glowPlayer = registerBoolean("Glow Player", "GlowPlayer", false);
     }
 
     GSColor playerColor;
@@ -61,7 +65,18 @@ public class ESP extends Module {
         mc.world.loadedEntityList.stream().filter(entity -> entity != mc.player).filter(entity -> rangeEntityCheck(entity)).forEach(entity -> {
             defineEntityColors(entity);
             if (playerRender.getValue() && entity instanceof EntityPlayer){
-                GameSenseTessellator.drawBoundingBox(entity.getEntityBoundingBox(), width.getValue(), playerColor);
+                // If glowing
+                if (glowPlayer.getValue()) {
+                    entity.setGlowing(true);
+                    System.out.println("");
+                }
+                else if (entity.isGlowing())
+                    entity.setGlowing(false);
+                // If the guy want to see the direction from the box
+                if (playerDirection.getValue())
+                    GameSenseTessellator.drawBoxWithDirection(entity.getEntityBoundingBox(), playerColor, ((EntityPlayer) entity).rotationYawHead);
+                else
+                    GameSenseTessellator.drawBoundingBox(entity.getEntityBoundingBox(), width.getValue(), playerColor);
             }
             if (mobRender.getValue()){
                 if (entity instanceof EntityCreature || entity instanceof EntitySlime || entity instanceof EntitySquid){


### PR DESCRIPTION
added direction mode and glowing mode to esp
**description:** just 2 new modes to esp, one show the direction of the player and the other it make the player glowing
**Why is this usefull?** Direction mode allow to see where everyone are looking by rotating the esp' square, glowing it's like a chams/wallhack (i'm working for creating a really chams/wallhack that is not glowing)
**Testing** i tested it on singleplayer and on crystalpvp.cc
[click here for the Image of direction mode](https://ibb.co/ggMg6Qs)
[click here for the Image of glowing mode](https://ibb.co/MhPpv8g)