### PR TITLE
AntiCrystal and bug fix

### DIFF
--- a/src/main/java/com/gamesense/api/config/LoadConfig.java
+++ b/src/main/java/com/gamesense/api/config/LoadConfig.java
@@ -135,7 +135,9 @@ public class LoadConfig {
 
             if (dataObject != null && dataObject.isJsonPrimitive()) {
                 if (dataObject.getAsBoolean() == true) {
-                    module.enable();
+                    try {
+                        module.enable();
+                    }catch (NullPointerException e) {}
                 }
             }
         }

--- a/src/main/java/com/gamesense/client/module/modules/combat/AutoCrystalGS.java
+++ b/src/main/java/com/gamesense/client/module/modules/combat/AutoCrystalGS.java
@@ -147,7 +147,7 @@ public class AutoCrystalGS extends Module {
     private int newSlot;
     private Entity renderEnt;
     private BlockPos render;
-    private final ArrayList<BlockPos> PlacedCrystals = new ArrayList<BlockPos>();
+    public static final ArrayList<BlockPos> PlacedCrystals = new ArrayList<BlockPos>();
     private EnumFacing enumFacing;
     Timer timer = new Timer();
 

--- a/src/main/java/com/gamesense/client/module/modules/combat/OffHand.java
+++ b/src/main/java/com/gamesense/client/module/modules/combat/OffHand.java
@@ -118,7 +118,7 @@ public class OffHand extends Module {
         // Potion
         shiftPot = registerBoolean("ShiftPot", true);
         // Sword check
-        swordCheck = registerBoolean("nonSword", true);
+        swordCheck = registerBoolean("onlySword", true);
         // Fall Distance
         fallDistanceBol = registerBoolean("Fall Distance", true);
         // Crystal Check


### PR DESCRIPTION
AntiCrystal:
- Added compatibility with autoCrystal (now it wont place crystals on your own)
- Added "nonAbusive" option (it wont switch to your pressure plate, only if you have it on your mainHand)
- Added switchBack (if it switched, it's going to go back as before)
- Added damage calculation (it is going to place a plate only if there is a specific damage)
Fix:
- Module crash on "module.enable()". I dont think this is going to fuck up everything, i tested and it works without any problems and crash.
OffHand:
- Renamed "nonSword" to "onlySword"