### PR TITLE
Fixed PacketXp

### DIFF
--- a/src/main/java/com/gamesense/client/module/modules/exploits/PacketXP.java
+++ b/src/main/java/com/gamesense/client/module/modules/exploits/PacketXP.java
@@ -1,17 +1,21 @@
 package com.gamesense.client.module.modules.exploits;
 
 import com.gamesense.api.setting.Setting;
+import com.gamesense.client.GameSense;
 import com.gamesense.client.module.Module;
+import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.client.CPacketPlayer;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Hoosiers
  * @since 12/14/2020
+ * @author 0b00101010
+ * @since 24/01/2021
  */
 
 public class PacketXP extends Module {
@@ -24,41 +28,61 @@ public class PacketXP extends Module {
     Setting.Integer maxHeal;
     Setting.Boolean noEntityCollision;
     Setting.Boolean sneakOnly;
+    Setting.Boolean predict;
 
     public void setup() {
         sneakOnly = registerBoolean("Sneak Only", true);
         noEntityCollision = registerBoolean("No Collision", true);
         minDamage = registerInteger("Min Damage", 50, 1, 100);
         maxHeal = registerInteger("Repair To", 90, 1, 100);
+        predict = registerBoolean("Predict", false);
     }
 
-    ArrayList<ItemStack> toMend = new ArrayList<>();
+    int toMend = 0;
 
     public void onUpdate() {
         if (mc.player == null || mc.world == null || mc.player.ticksExisted < 10) {
             return;
         }
 
-        for (ItemStack itemStack : mc.player.inventory.armorInventory) {
+        int sumOfDamage = 0;
+
+        List<ItemStack> armour = mc.player.inventory.armorInventory;
+        for (int i = 0; i < armour.size(); i++) {
+            ItemStack itemStack = armour.get(i);
             if (itemStack.isEmpty) {
                 continue;
             }
 
             //this works better than my calculation for some reason, thank you ArmorHUD.java
-            float damagePercent1 = 1 - ((itemStack.getMaxDamage() - itemStack.getItemDamage()) / itemStack.getMaxDamage());
-            float damagePercent2 = 100 - (100 * damagePercent1);
+            float damageOnArmor = (float)(itemStack.getMaxDamage() - itemStack.getItemDamage());
+            float damagePercent = 100 - (100 * (1 - damageOnArmor/ itemStack.getMaxDamage()));
 
-            if (damagePercent2 <= minDamage.getValue() && !toMend.contains(itemStack)) {
-                toMend.add(itemStack);
-            }
-
-            if (damagePercent2 >= maxHeal.getValue() && toMend.contains(itemStack)) {
-                toMend.remove(itemStack);
+            if (damagePercent <= maxHeal.getValue()) {
+                if (damagePercent <= minDamage.getValue()) {
+                    toMend |= 1 << i;
+                }
+                if (predict.getValue()) {
+                    sumOfDamage += (itemStack.getItemDamage() * maxHeal.getValue() / 100f);
+                }
+            } else {
+                toMend &= ~(1 << i);
             }
         }
 
-        if (toMend.size() > 0) {
-            mendArmor(mc.player.inventory.currentItem);
+        if (toMend > 0) {
+            if (predict.getValue()) {
+                int totalXp = mc.world.loadedEntityList.stream()
+                        .filter(entity -> entity instanceof EntityXPOrb)
+                        .filter(entity -> entity.getDistanceSq(mc.player) <= 1)
+                        .mapToInt(entity -> ((EntityXPOrb) entity).xpValue).sum();
+
+                if ((totalXp * 2) < sumOfDamage) {
+                    mendArmor(mc.player.inventory.currentItem);
+                }
+            } else {
+                mendArmor(mc.player.inventory.currentItem);
+            }
         }
     }
 

--- a/src/main/java/com/gamesense/client/module/modules/exploits/PacketXP.java
+++ b/src/main/java/com/gamesense/client/module/modules/exploits/PacketXP.java
@@ -1,7 +1,6 @@
 package com.gamesense.client.module.modules.exploits;
 
 import com.gamesense.api.setting.Setting;
-import com.gamesense.client.GameSense;
 import com.gamesense.client.module.Module;
 import net.minecraft.entity.item.EntityXPOrb;
 import net.minecraft.entity.player.EntityPlayer;
@@ -38,7 +37,15 @@ public class PacketXP extends Module {
         predict = registerBoolean("Predict", false);
     }
 
-    int toMend = 0;
+    /*
+     * each armour slot is represented by a bit
+     * 1 for needs healing
+     * only the lower 4 bits are used
+     * it is stored like this as toMend > 0
+     * can be used to check to see if we need to mend
+     * simplifying the logic
+     */
+    char toMend = 0;
 
     public void onUpdate() {
         if (mc.player == null || mc.world == null || mc.player.ticksExisted < 10) {
@@ -63,7 +70,7 @@ public class PacketXP extends Module {
                     toMend |= 1 << i;
                 }
                 if (predict.getValue()) {
-                    sumOfDamage += (itemStack.getItemDamage() * maxHeal.getValue() / 100f);
+                    sumOfDamage += (itemStack.getMaxDamage() * maxHeal.getValue() / 100f) - (itemStack.getMaxDamage() - itemStack.getItemDamage());
                 }
             } else {
                 toMend &= ~(1 << i);
@@ -72,11 +79,13 @@ public class PacketXP extends Module {
 
         if (toMend > 0) {
             if (predict.getValue()) {
+                // get all the xp orbs on top of us
                 int totalXp = mc.world.loadedEntityList.stream()
                         .filter(entity -> entity instanceof EntityXPOrb)
                         .filter(entity -> entity.getDistanceSq(mc.player) <= 1)
                         .mapToInt(entity -> ((EntityXPOrb) entity).xpValue).sum();
 
+                // see EntityXpOrbxpToDurability(int xp)
                 if ((totalXp * 2) < sumOfDamage) {
                     mendArmor(mc.player.inventory.currentItem);
                 }


### PR DESCRIPTION
MaxHeal/ minDamage weren't working due to leak in memory in "toMend" array.

Added new mode: Predict
Predict stops the use of XpBottles when there are enough orbs to heal armour to "maxHeal".

Note: due to the random nature of mending, will not always perform as expected.