### PR TITLE
Reworked CityESP and updated HoleUtil

### DIFF
--- a/src/main/java/com/gamesense/api/util/world/EntityUtil.java
+++ b/src/main/java/com/gamesense/api/util/world/EntityUtil.java
@@ -114,6 +114,24 @@ public class EntityUtil {
 		return circleblocks;
 	}
 
+	public static List<BlockPos> getSquare(BlockPos pos1, BlockPos pos2) {
+		List<BlockPos> squareBlocks = new ArrayList<>();
+		int x1 = pos1.getX();
+		int y1 = pos1.getY();
+		int z1 = pos1.getZ();
+		int x2 = pos2.getX();
+		int y2 = pos2.getY();
+		int z2 = pos2.getZ();
+		for (int x = Math.min(x1, x2); x <= Math.max(x1, x2); x += 1) {
+			for (int z = Math.min(z1, z2); z <= Math.max(z1, z2); z += 1) {
+				for (int y = Math.min(y1, y2); y <= Math.max(y1, y2); y += 1) {
+					squareBlocks.add(new BlockPos(x, y, z));
+				}
+			}
+		}
+		return squareBlocks;
+	}
+
 	public static double[] calculateLookAt(double px, double py, double pz, Entity me) {
 		double dirx = me.posX - px;
 		double diry = me.posY - py;
@@ -137,11 +155,10 @@ public class EntityUtil {
 	}
 
 	// Basic checks for an entity
-	// needed for crystal aura to not target freecam;
+	// needed for crystal aura to not target freecam
 	public static boolean basicChecksEntity(Entity pl) {
 		return pl.getName().equals(mc.player.getName()) || Friends.isFriend(pl.getName()) || pl.isDead;
 	}
-
 
 	public static BlockPos getPosition(Entity pl) {
 		return new BlockPos(Math.floor(pl.posX), Math.floor(pl.posY), Math.floor(pl.posZ));
@@ -150,9 +167,9 @@ public class EntityUtil {
 	public static List<BlockPos> getBlocksIn(Entity pl) {
 		List<BlockPos> blocks = new ArrayList<>();
 		AxisAlignedBB bb = pl.getEntityBoundingBox();
-		for (double x = bb.minX; x < bb.maxX; x++) {
-			for (double y = bb.minY; x < bb.maxY; y++) {
-				for (double z = bb.minZ; x < bb.maxZ; z++) {
+		for (double x = Math.floor(bb.minX); x < Math.ceil(bb.maxX); x++) {
+			for (double y = Math.floor(bb.minY); y < Math.ceil(bb.maxY); y++) {
+				for (double z = Math.floor(bb.minZ); z < Math.ceil(bb.maxZ); z++) {
 					blocks.add(new BlockPos(x, y, z));
 				}
 			}

--- a/src/main/java/com/gamesense/api/util/world/HoleUtil.java
+++ b/src/main/java/com/gamesense/api/util/world/HoleUtil.java
@@ -22,14 +22,16 @@ public class HoleUtil {
         return BlockSafety.BREAKABLE;
     }
 
-    public static HoleInfo isHole(BlockPos centreBlock, boolean onlyOneWide) {
+    public static HoleInfo isHole(BlockPos centreBlock, boolean onlyOneWide, boolean ignoreDown) {
         HoleInfo output = new HoleInfo();
         HashMap<HoleUtil.BlockOffset, HoleUtil.BlockSafety> unsafeSides = HoleUtil.getUnsafeSides(centreBlock);
 
         if (unsafeSides.containsKey(HoleUtil.BlockOffset.DOWN)) {
             if (unsafeSides.remove(HoleUtil.BlockOffset.DOWN, HoleUtil.BlockSafety.BREAKABLE)) {
-                output.setSafety(BlockSafety.BREAKABLE);
-                return output;
+                if (!ignoreDown) {
+                    output.setSafety(BlockSafety.BREAKABLE);
+                    return output;
+                }
             }
         }
 
@@ -59,7 +61,7 @@ public class HoleUtil {
         }
     }
 
-    public static HoleInfo isDoubleHole(HoleInfo info, BlockPos centreBlock, BlockOffset weakSide) {
+    private static HoleInfo isDoubleHole(HoleInfo info, BlockPos centreBlock, BlockOffset weakSide) {
         BlockPos unsafePos = weakSide.offset(centreBlock);
 
         HashMap<HoleUtil.BlockOffset, HoleUtil.BlockSafety> unsafeSides = HoleUtil.getUnsafeSides(unsafePos);
@@ -181,9 +183,9 @@ public class HoleUtil {
         DOWN(0, -1, 0),
         UP(0, 1, 0),
         NORTH(0, 0, -1),
+        EAST(1, 0, 0),
         SOUTH(0, 0, 1),
-        WEST(-1, 0, 0),
-        EAST(1, 0, 0);
+        WEST(-1, 0, 0);
 
         private final int x;
         private final int y;
@@ -197,6 +199,24 @@ public class HoleUtil {
 
         public BlockPos offset(BlockPos pos) {
             return pos.add(x, y, z);
+        }
+
+        public BlockPos forward(BlockPos pos, int scale) {
+            return pos.add(x * scale, 0, z * scale);
+        }
+
+        public BlockPos backward(BlockPos pos, int scale) {
+            return pos.add(-x * scale, 0, -z * scale);
+        }
+
+        // Don't ask me why they work but they do
+
+        public BlockPos left(BlockPos pos, int scale) {
+            return pos.add(z * scale, 0, -x * scale);
+        }
+
+        public BlockPos right(BlockPos pos, int scale) {
+            return pos.add(-z * scale, 0, x * scale);
         }
     }
 }

--- a/src/main/java/com/gamesense/client/module/modules/combat/AutoAnvil.java
+++ b/src/main/java/com/gamesense/client/module/modules/combat/AutoAnvil.java
@@ -3,6 +3,8 @@ package com.gamesense.client.module.modules.combat;
 import com.gamesense.api.setting.Setting;
 import com.gamesense.api.util.player.PlayerUtil;
 import com.gamesense.api.util.world.BlockUtil;
+import com.gamesense.api.util.world.EntityUtil;
+import com.gamesense.api.util.world.HoleUtil;
 import com.gamesense.client.module.Module;
 import com.gamesense.client.module.ModuleManager;
 import net.minecraft.block.*;
@@ -512,23 +514,13 @@ public class AutoAnvil extends Module {
     }
 
     private boolean is_in_hole() {
-        sur_block = new Double[][] {
-                {aimTarget.posX + 1, aimTarget.posY, aimTarget.posZ},
-                {aimTarget.posX - 1, aimTarget.posY, aimTarget.posZ},
-                {aimTarget.posX, aimTarget.posY, aimTarget.posZ + 1},
-                {aimTarget.posX, aimTarget.posY, aimTarget.posZ - 1}
-        };
-
         enemyCoords = new double[] {
                 aimTarget.posX,
                 aimTarget.posY,
                 aimTarget.posZ
         };
         // Check if the guy is in a hole
-        return !(BlockUtil.getBlock(sur_block[0][0], sur_block[0][1], sur_block[0][2]) instanceof BlockAir) &&
-                !(BlockUtil.getBlock(sur_block[1][0], sur_block[1][1], sur_block[1][2]) instanceof BlockAir) &&
-                !(BlockUtil.getBlock(sur_block[2][0], sur_block[2][1], sur_block[2][2]) instanceof BlockAir) &&
-                !(BlockUtil.getBlock(sur_block[3][0], sur_block[3][1], sur_block[3][2]) instanceof BlockAir);
+        return HoleUtil.isHole(EntityUtil.getPosition(aimTarget), true, true).getType() != HoleUtil.HoleType.NONE;
     }
 
     private boolean createStructure() {

--- a/src/main/java/com/gamesense/client/module/modules/combat/HoleFill.java
+++ b/src/main/java/com/gamesense/client/module/modules/combat/HoleFill.java
@@ -167,7 +167,7 @@ public class HoleFill extends Module {
 		List<BlockPos> blockPosList = EntityUtil.getSphere(PlayerUtil.getPlayerPos(), 5, 5, false, true, 0);
 
 		for (BlockPos blockPos : blockPosList) {
-			if (HoleUtil.isHole(blockPos, true).getType() == HoleUtil.HoleType.SINGLE) {
+			if (HoleUtil.isHole(blockPos, true, true).getType() == HoleUtil.HoleType.SINGLE) {
 				holes.add(blockPos);
 			}
 		}

--- a/src/main/java/com/gamesense/client/module/modules/combat/PistonCrystal.java
+++ b/src/main/java/com/gamesense/client/module/modules/combat/PistonCrystal.java
@@ -5,6 +5,8 @@ import com.gamesense.api.util.combat.CrystalUtil;
 import com.gamesense.api.util.misc.MessageBus;
 import com.gamesense.api.util.player.PlayerUtil;
 import com.gamesense.api.util.world.BlockUtil;
+import com.gamesense.api.util.world.EntityUtil;
+import com.gamesense.api.util.world.HoleUtil;
 import com.gamesense.client.module.Module;
 import com.gamesense.client.module.ModuleManager;
 import com.gamesense.client.module.modules.gui.ColorMain;
@@ -194,7 +196,7 @@ public class PistonCrystal extends Module {
         // Get all the materials
         if (getMaterialsSlot()) {
             // check if the enemy is in a hole
-            if (is_in_hole()) {
+            if (HoleUtil.isHole(EntityUtil.getPosition(aimTarget), true, true).getType() != HoleUtil.HoleType.NONE) {
                 // Get enemy coordinates
                 enemyCoordsDouble = new double[] {aimTarget.posX, aimTarget.posY, aimTarget.posZ};
                 enemyCoordsInt = new int[] {(int) enemyCoordsDouble[0], (int) enemyCoordsDouble[1], (int) enemyCoordsDouble[2]};
@@ -1354,23 +1356,6 @@ public class PistonCrystal extends Module {
         // If we have everything we need, return true
         return count >= 4 + (antiWeakness.getValue() ? 1 : 0) + (redstoneBlockMode ? 1 : 0);
 
-    }
-
-    // Check if it's in a hole
-    private boolean is_in_hole() {
-        sur_block = new Double[][] {
-                {aimTarget.posX + 1, aimTarget.posY, aimTarget.posZ},
-                {aimTarget.posX - 1, aimTarget.posY, aimTarget.posZ},
-                {aimTarget.posX, aimTarget.posY, aimTarget.posZ + 1},
-                {aimTarget.posX, aimTarget.posY, aimTarget.posZ - 1}
-        };
-
-        
-        // Check if the guy is in a hole
-        return !(BlockUtil.getBlock(sur_block[0][0], sur_block[0][1], sur_block[0][2]) instanceof BlockAir) &&
-                !(BlockUtil.getBlock(sur_block[1][0], sur_block[1][1], sur_block[1][2]) instanceof BlockAir) &&
-                !(BlockUtil.getBlock(sur_block[2][0], sur_block[2][1], sur_block[2][2]) instanceof BlockAir) &&
-                !(BlockUtil.getBlock(sur_block[3][0], sur_block[3][1], sur_block[3][2]) instanceof BlockAir);
     }
 
     // PrintChat

--- a/src/main/java/com/gamesense/client/module/modules/movement/Anchor.java
+++ b/src/main/java/com/gamesense/client/module/modules/movement/Anchor.java
@@ -66,7 +66,6 @@ public class Anchor extends Module {
                 if (sides.size() == 0) {
                     mc.player.motionX = 0f;
                     mc.player.motionZ = 0f;
-                    GameSense.LOGGER.info(i);
                 }
             }
         }

--- a/src/main/java/com/gamesense/client/module/modules/movement/HoleTP.java
+++ b/src/main/java/com/gamesense/client/module/modules/movement/HoleTP.java
@@ -12,10 +12,8 @@ import net.minecraft.network.play.client.CPacketPlayer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 
-import java.util.HashMap;
-
 /**
- * @author unkown
+ * @author unknown
  * @author 0b00101010
  * @since 25/01/21
  */
@@ -76,9 +74,7 @@ public class HoleTP extends Module {
 	}
 
 	private boolean isSafeHole(BlockPos blockPos) {
-		HashMap<HoleUtil.BlockOffset, HoleUtil.BlockSafety> sides = HoleUtil.getUnsafeSides(blockPos);
-		sides.entrySet().removeIf(entry -> entry.getValue() == HoleUtil.BlockSafety.RESISTANT);
-		return sides.size() == 0;
+		return HoleUtil.isHole(blockPos, true, false).getType() != HoleUtil.HoleType.NONE;
 	}
 
 	private boolean isOnLiquid() {

--- a/src/main/java/com/gamesense/client/module/modules/render/CityESP.java
+++ b/src/main/java/com/gamesense/client/module/modules/render/CityESP.java
@@ -2,34 +2,44 @@ package com.gamesense.client.module.modules.render;
 
 import com.gamesense.api.event.events.RenderEvent;
 import com.gamesense.api.setting.Setting;
-import com.gamesense.api.util.player.friend.Friends;
+import com.gamesense.api.util.combat.CrystalUtil;
+import com.gamesense.api.util.combat.DamageUtil;
 import com.gamesense.api.util.render.GSColor;
 import com.gamesense.api.util.render.RenderUtil;
+import com.gamesense.api.util.world.EntityUtil;
 import com.gamesense.api.util.world.GeometryMasks;
+import com.gamesense.api.util.world.HoleUtil;
 import com.gamesense.client.module.Module;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
-import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 /**
- * @Author Hoosiers on 10/20/2020
+ * @author Hoosiers
+ * @since 10/20/2020
+ * @author 0b00101010
+ * @since 30/01/2021
  */
-
 public class CityESP extends Module {
 
     public CityESP() {
         super("CityESP", Category.Render);
     }
 
+    Setting.Integer range;
+    Setting.Integer down;
+    Setting.Integer sides;
+    Setting.Integer depth;
+    Setting.Double minDamage;
+    Setting.Double maxDamage;
     Setting.Mode targetMode;
     Setting.Mode selectMode;
     Setting.Mode renderMode;
-    Setting.Integer range;
     Setting.Integer width;
     Setting.ColorSetting color;
 
@@ -48,6 +58,11 @@ public class CityESP extends Module {
         renderModes.add("Both");
 
         range = registerInteger("Range", 20, 1, 30);
+        down = registerInteger("Down", 1, 0, 3);
+        sides = registerInteger("Sides", 1, 0, 4);
+        depth = registerInteger("Depth", 3, 0, 10);
+        minDamage = registerDouble("Min Damage", 5, 0, 10);
+        maxDamage = registerDouble("Max Self Damage", 7, 0, 20);
         targetMode = registerMode("Target", targetModes, "Single");
         selectMode = registerMode("Select", selectModes, "Closest");
         renderMode = registerMode("Render", renderModes, "Both");
@@ -55,87 +70,135 @@ public class CityESP extends Module {
         color = registerColor("Color", new GSColor(102,51,153));
     }
 
+    private final HashMap<EntityPlayer, List<BlockPos>> cityable = new HashMap<>();
+
+    public void onUpdate() {
+        if (mc.player == null || mc.world == null)
+            return;
+
+        cityable.clear();
+
+        List<EntityPlayer> players = mc.world.playerEntities.stream()
+                .filter(entityPlayer -> entityPlayer.getDistanceSq(mc.player) <= range.getValue() * range.getValue())
+                .filter(entityPlayer -> !EntityUtil.basicChecksEntity(entityPlayer)).collect(Collectors.toList());
+
+        for (EntityPlayer player: players) {
+            if (player == mc.player) {
+                continue;
+            }
+
+            List<BlockPos> blocks = EntityUtil.getBlocksIn(player);
+            if (blocks.size() == 0) {
+                continue;
+            }
+
+            // find lowest point of the player
+            int minY = Integer.MAX_VALUE;
+            for (BlockPos block : blocks) {
+                int y = block.getY();
+                if (y < minY) {
+                    minY = y;
+                }
+            }
+
+            int finalMinY = minY;
+            blocks = blocks.stream().filter(blockPos -> blockPos.getY() == finalMinY).collect(Collectors.toList());
+
+            Optional<BlockPos> any = blocks.stream().findAny();
+            if (!any.isPresent()) {
+                continue;
+            }
+
+            // check if player is actually in a hole
+            HoleUtil.HoleInfo holeInfo = HoleUtil.isHole(any.get(), false, true);
+            if (holeInfo.getType() == HoleUtil.HoleType.NONE || holeInfo.getSafety() == HoleUtil.BlockSafety.UNBREAKABLE) {
+                continue;
+            }
+
+            List<BlockPos> sides = new ArrayList<>();
+            for (BlockPos block : blocks) {
+                sides.addAll(cityableSides(block, HoleUtil.getUnsafeSides(block).keySet(), player));
+            }
+
+            if (sides.size() > 0) {
+                cityable.put(player, sides);
+            }
+        }
+    }
+
     public void onWorldRender(RenderEvent event) {
-        if (mc.player != null || mc.world != null) {
-            mc.world.playerEntities.stream()
-                    .filter(entityPlayer -> entityPlayer.getDistance(mc.player) <= range.getValue())
-                    .filter(entityPlayer -> entityPlayer != mc.player)
-                    .filter(entityPlayer ->  !Friends.isFriend(entityPlayer.getName()))
-                    .forEach(entityPlayer -> {
+        AtomicBoolean noRender = new AtomicBoolean(false);
 
-                        if (entityPlayer == mc.player) {
-                            return;
+        cityable.entrySet().stream().sorted((entry, entry1) -> (int) entry.getKey().getDistanceSq(entry1.getKey())).forEach((entry) -> {
+            if (noRender.get()) {
+                return;
+            }
+            renderBoxes(entry.getValue());
+            if (targetMode.getValue().equalsIgnoreCase("All")) {
+                noRender.set(true);
+            }
+        });
+    }
+
+    private List<BlockPos> cityableSides(BlockPos centre, Set<HoleUtil.BlockOffset> weakSides, EntityPlayer player) {
+        List<BlockPos> cityableSides = new ArrayList<>();
+        HashMap<BlockPos, HoleUtil.BlockOffset> directions = new HashMap<>();
+        for (HoleUtil.BlockOffset weakSide : weakSides) {
+            BlockPos pos = weakSide.offset(centre);
+            if (mc.world.getBlockState(pos).getBlock() != Blocks.AIR) {
+                directions.put(pos, weakSide);
+            }
+        }
+
+        directions.forEach(((blockPos, blockOffset) -> {
+            if (blockOffset == HoleUtil.BlockOffset.DOWN) {
+                return;
+            }
+
+            BlockPos pos1 = blockOffset.left(blockPos.down(down.getValue()), sides.getValue());
+            BlockPos pos2 = blockOffset.forward(blockOffset.right(blockPos, sides.getValue()), depth.getValue());
+            List<BlockPos> square = EntityUtil.getSquare(pos1, pos2);
+            // store to put back after calculation
+            IBlockState holder = mc.world.getBlockState(blockPos);
+            mc.world.setBlockToAir(blockPos);
+
+
+            for (BlockPos pos : square) {
+                if (CrystalUtil.canPlaceCrystal(pos.down(), false)) {
+                    // believe i have the right location for the crystal
+                    // pos is the block one above the bedrock/obsidian
+                    if (DamageUtil.calculateDamage((double) pos.getX() + 0.5d, pos.getY(), (double) pos.getZ()+ 0.5d, player) >= minDamage.getValue()) {
+                        if (DamageUtil.calculateDamage((double) pos.getX() + 0.5d, pos.getY(), (double) pos.getZ()+ 0.5d, mc.player) <= maxDamage.getValue()) {
+                            cityableSides.add(blockPos);
                         }
+                        break;
+                    }
+                }
+            }
 
-                        if (isTrapped(entityPlayer)) {
-                            List<BlockPos> renderBlocks = new ArrayList<>();
-                            renderBlocks.addAll(getBlocksToRender(entityPlayer));
+            // put back
+            mc.world.setBlockState(blockPos, holder);
+        }));
 
-                            if (renderBlocks != null) {
-                                renderBox(renderBlocks);
-                            }
-
-                            if (targetMode.getValue().equalsIgnoreCase("All")) {
-                                return;
-                            }
-                        }
-                    });
-        }
+        return cityableSides;
     }
 
-    private boolean isTrapped(EntityPlayer entityPlayer) {
-        BlockPos blockPos = new BlockPos(entityPlayer.posX, entityPlayer.posY, entityPlayer.posZ);
-
-        //minimum amount of blocks needed to be "trapped"
-        return mc.world.getBlockState(blockPos.east()).getBlock() != Blocks.AIR
-                && mc.world.getBlockState(blockPos.west()).getBlock() != Blocks.AIR
-                && mc.world.getBlockState(blockPos.north()).getBlock() != Blocks.AIR
-                && mc.world.getBlockState(blockPos.south()).getBlock() != Blocks.AIR
-                && mc.world.getBlockState(blockPos.up(2)).getBlock() != Blocks.AIR
-                && mc.world.getBlockState(blockPos.down()).getBlock() != Blocks.AIR;
-    }
-
-    //this doesn't check if there is a block below the target block, might add it later if people want it
-    private List<BlockPos> getBlocksToRender(EntityPlayer entityPlayer) {
-        NonNullList<BlockPos> blockPosList = NonNullList.create();
-        BlockPos blockPos = new BlockPos(entityPlayer.posX, entityPlayer.posY, entityPlayer.posZ);
-
-        if (mc.world.getBlockState(blockPos.east()).getBlock() != Blocks.BEDROCK) {
-            blockPosList.add(blockPos.east());
-        }
-        if (mc.world.getBlockState(blockPos.west()).getBlock() != Blocks.BEDROCK) {
-            blockPosList.add(blockPos.west());
-        }
-        if (mc.world.getBlockState(blockPos.north()).getBlock() != Blocks.BEDROCK) {
-            blockPosList.add(blockPos.north());
-        }
-        if (mc.world.getBlockState(blockPos.south()).getBlock() != Blocks.BEDROCK) {
-            blockPosList.add(blockPos.south());
-        }
-
-        return blockPosList;
-    }
-
-    private void renderBox(List<BlockPos> blockPosList) {
+    private void renderBoxes(List<BlockPos> blockPosList) {
         switch (selectMode.getValue()) {
             case "Closest": {
-                BlockPos renderPos = blockPosList.stream().sorted(Comparator.comparing(blockPos -> blockPos.getDistance((int) mc.player.posX, (int) mc.player.posY, (int) mc.player.posZ))).findFirst().orElse(null);
-
-                if (renderPos != null) {
-                    renderBox2(renderPos);
-                }
+                blockPosList.stream().min(Comparator.comparing(blockPos -> blockPos.distanceSq((int) mc.player.posX, (int) mc.player.posY, (int) mc.player.posZ))).ifPresent(this::renderBox);
                 break;
             }
             case "All": {
                 for (BlockPos blockPos : blockPosList) {
-                    renderBox2(blockPos);
+                    renderBox(blockPos);
                 }
                 break;
             }
         }
     }
 
-    private void renderBox2(BlockPos blockPos) {
+    private void renderBox(BlockPos blockPos) {
         GSColor gsColor1 = new GSColor(color.getValue(), 255);
         GSColor gsColor2 = new GSColor(color.getValue(), 50);
 

--- a/src/main/java/com/gamesense/client/module/modules/render/CityESP.java
+++ b/src/main/java/com/gamesense/client/module/modules/render/CityESP.java
@@ -123,14 +123,6 @@ public class CityESP extends Module {
             if (sides.size() > 0) {
                 cityable.put(player, sides);
             }
-                        if (isTrapped(entityPlayer)) {
-                            List<BlockPos> renderBlocks = new ArrayList<>(getBlocksToRender(entityPlayer));
-
-                            if (renderBlocks != null) {
-                                renderBox(renderBlocks);
-                            }
-                        }
-                    });
         }
     }
 

--- a/src/main/java/com/gamesense/client/module/modules/render/HoleESP.java
+++ b/src/main/java/com/gamesense/client/module/modules/render/HoleESP.java
@@ -127,7 +127,7 @@ public class HoleESP extends Module {
         }
 
         possibleHoles.forEach(pos -> {
-            HoleUtil.HoleInfo holeInfo = HoleUtil.isHole(pos, false);
+            HoleUtil.HoleInfo holeInfo = HoleUtil.isHole(pos, false, false);
             HoleUtil.HoleType holeType = holeInfo.getType();
             if (holeType != HoleUtil.HoleType.NONE) {
                 // We have a hole!


### PR DESCRIPTION
Removed some left over debug lines.

Reworked CityESP to use damage calculations to accurately show which sides are cityable with immediate effect of dealing damage to the other player. Uses side, down and depth to find the area to search for a suitable damage location. Side works on each side, so with side being equal to 1 the actual width to search would be 3 (default 1 width).