### PR TITLE
surround + offHand

### DIFF
--- a/src/main/java/com/gamesense/client/module/modules/combat/OffHand.java
+++ b/src/main/java/com/gamesense/client/module/modules/combat/OffHand.java
@@ -11,7 +11,6 @@ package com.gamesense.client.module.modules.combat;
 
 import com.gamesense.api.setting.Setting;
 import com.gamesense.api.util.combat.DamageUtil;
-import com.gamesense.api.util.misc.MessageBus;
 import com.gamesense.client.module.Module;
 import com.mojang.realmsclient.gui.ChatFormatting;
 import net.minecraft.block.Block;
@@ -41,7 +40,7 @@ public class OffHand extends Module {
     Setting.Integer tickDelay;
     Setting.Integer fallDistance;
     Setting.Double biasDamage;
-    Setting.Boolean crystalObby;
+    Setting.Boolean pickObby;
     Setting.Boolean leftGap;
     Setting.Boolean shiftPot;
     Setting.Boolean swordCheck;
@@ -50,6 +49,8 @@ public class OffHand extends Module {
     Setting.Boolean antiWeakness;
     Setting.Boolean chatMsg;
     Setting.Boolean noHotBar;
+    Setting.Boolean crystObby;
+    Setting.Boolean pickObbyShift;
 
     int prevSlot,
         tickWaited,
@@ -117,7 +118,11 @@ public class OffHand extends Module {
         // Bias Damage
         biasDamage = registerDouble("Bias Damage", 1, 0, 3);
         // obby
-        crystalObby = registerBoolean("Shift Cryst Obby", true);
+        pickObby = registerBoolean("Pick Obby", true);
+        // Enable pickObby only in shift
+        pickObbyShift = registerBoolean("Pick Obby On Shift", true);
+        // If you want crystal to offHand
+        crystObby = registerBoolean("Cryst Shift Obby", false);
         // Gapple
         leftGap = registerBoolean("Left Click Gap", true);
         // Potion
@@ -225,22 +230,27 @@ public class OffHand extends Module {
             itemCheck = "Crystal";
         }
 
-        // If obby
-        if((normalOffHand && crystalObby.getValue() && mc.gameSettings.keyBindSneak.isKeyDown()
-                && mc.player.getHeldItemMainhand().getItem() == Items.END_CRYSTAL)
-            || forceObby > 0) {
+        Item mainHandItem = mc.player.getHeldItemMainhand().getItem();
+
+        // If crystal obby
+        if( forceObby > 0
+            || (normalOffHand && (
+            (crystObby.getValue() && mc.gameSettings.keyBindSneak.isKeyDown()
+            && mainHandItem == Items.END_CRYSTAL)
+            || (pickObby.getValue() && mainHandItem == Items.DIAMOND_PICKAXE && (!pickObbyShift.getValue() || mc.gameSettings.keyBindSneak.isKeyDown()))))) {
             itemCheck = "Obby";
             normalOffHand = false;
         }
 
-        if (normalOffHand && mc.gameSettings.keyBindUseItem.isKeyDown() && (!swordCheck.getValue() || mc.player.getHeldItemMainhand().getItem() == Items.DIAMOND_SWORD)) {
+        // Gap + Pot
+        if (normalOffHand && mc.gameSettings.keyBindUseItem.isKeyDown() && (!swordCheck.getValue() || mainHandItem == Items.DIAMOND_SWORD)) {
             if(mc.gameSettings.keyBindSneak.isKeyDown()) {
                 if(shiftPot.getValue()) {
                     itemCheck = "Pot";
                     normalOffHand = false;
                 }
             }else
-            if (leftGap.getValue() && mc.player.getHeldItemMainhand().getItem() != Items.GOLDEN_APPLE) {
+            if (leftGap.getValue() && mainHandItem != Items.GOLDEN_APPLE && mainHandItem != Items.EXPERIENCE_BOTTLE) {
                 itemCheck = "Gapple";
                 normalOffHand = false;
             }

--- a/src/main/java/com/gamesense/client/module/modules/combat/Surround.java
+++ b/src/main/java/com/gamesense/client/module/modules/combat/Surround.java
@@ -230,9 +230,8 @@ public class Surround extends Module {
             boolean tryPlacing = true;
 
             // Lets check if we are on a enderchest
-            if ((int)((mc.player.posY - (int) mc.player.posY) * 100) > 0 ) {
-                BlockPos t = targetPos;
-                targetPos = new BlockPos(t.getX(), t.getY() + 1, t.getZ());
+            if ( mc.player.posY % 1 > .2 ) {
+                targetPos = new BlockPos(targetPos.getX(), targetPos.getY() + 1, targetPos.getZ());
             }
 
             if (!mc.world.getBlockState(targetPos).getMaterial().isReplaceable()) {

--- a/src/main/java/com/gamesense/client/module/modules/combat/Surround.java
+++ b/src/main/java/com/gamesense/client/module/modules/combat/Surround.java
@@ -229,6 +229,12 @@ public class Surround extends Module {
 
             boolean tryPlacing = true;
 
+            // Lets check if we are on a enderchest
+            if ((int)((mc.player.posY - (int) mc.player.posY) * 100) == 87 ) {
+                BlockPos t = targetPos;
+                targetPos = new BlockPos(t.getX(), t.getY() + 1, t.getZ());
+            }
+
             if (!mc.world.getBlockState(targetPos).getMaterial().isReplaceable()) {
                 tryPlacing = false;
             }
@@ -281,16 +287,20 @@ public class Surround extends Module {
 
     private static class Offsets {
         private static final Vec3d[] SURROUND = {
-                new Vec3d(1, 0, 0),
-                new Vec3d(0, 0, 1),
-                new Vec3d(-1, 0, 0),
-                new Vec3d(0, 0, -1),
                 new Vec3d(1, -1, 0),
                 new Vec3d(0, -1, 1),
                 new Vec3d(-1, -1, 0),
-                new Vec3d(0, -1, -1)
+                new Vec3d(0, -1, -1),
+                new Vec3d(1, 0, 0),
+                new Vec3d(0, 0, 1),
+                new Vec3d(-1, 0, 0),
+                new Vec3d(0, 0, -1)
         };
         private static final Vec3d[] CITY = {
+                new Vec3d(1, -1, 0),
+                new Vec3d(0, -1, 1),
+                new Vec3d(-1, -1, 0),
+                new Vec3d(0, -1, -1),
                 new Vec3d(2, 0, 0),
                 new Vec3d(-2, 0, 0),
                 new Vec3d(0, 0, 2),
@@ -298,11 +308,7 @@ public class Surround extends Module {
                 new Vec3d(1, 0, 0),
                 new Vec3d(0, 0, 1),
                 new Vec3d(-1, 0, 0),
-                new Vec3d(0, 0, -1),
-                new Vec3d(1, -1, 0),
-                new Vec3d(0, -1, 1),
-                new Vec3d(-1, -1, 0),
-                new Vec3d(0, -1, -1)
+                new Vec3d(0, 0, -1)
         };
     }
 }

--- a/src/main/java/com/gamesense/client/module/modules/combat/Surround.java
+++ b/src/main/java/com/gamesense/client/module/modules/combat/Surround.java
@@ -230,7 +230,7 @@ public class Surround extends Module {
             boolean tryPlacing = true;
 
             // Lets check if we are on a enderchest
-            if ((int)((mc.player.posY - (int) mc.player.posY) * 100) == 87 ) {
+            if ((int)((mc.player.posY - (int) mc.player.posY) * 100) > 0 ) {
                 BlockPos t = targetPos;
                 targetPos = new BlockPos(t.getX(), t.getY() + 1, t.getZ());
             }

--- a/src/main/java/com/gamesense/client/module/modules/misc/AutoGear.java
+++ b/src/main/java/com/gamesense/client/module/modules/misc/AutoGear.java
@@ -70,10 +70,10 @@ public class AutoGear extends Module {
     @Override
     public void setup() {
         tickDelay = registerInteger("Tick Delay", 0, 0, 20);
-        debugMode = registerBoolean("Debug Mode", true);
         activeSort = registerBoolean("Active Sort", false);
         confirmSort = registerBoolean("Confirm Sort", true);
         chatMsg = registerBoolean("Chat Msg", true);
+        debugMode = registerBoolean("Debug Mode", true);
     }
 
     @Override


### PR DESCRIPTION
offHand: added new option, pickObby. This is usefull because, when you are bedrock cpvp, if you use the crystal for the obby, you wont place the obby but the crystal. pickObby is for bedrockCpvp, crystalObby for non-bedrock pvp
Surround: fix bug with half blocks