### PR TITLE
Fixed gray render in other mods

### DIFF
--- a/src/main/java/com/gamesense/api/util/render/RenderUtil.java
+++ b/src/main/java/com/gamesense/api/util/render/RenderUtil.java
@@ -425,7 +425,6 @@ public class RenderUtil {
 		GL11.glDisable(GL11.GL_LINE_SMOOTH);
 		GlStateManager.enableAlpha();
 		GlStateManager.enableCull();
-		GlStateManager.enableLighting();
 		GlStateManager.enableTexture2D();
 		GlStateManager.enableDepth();
 		GlStateManager.disableBlend();


### PR DESCRIPTION
GL_LIGHTING is disabled during RenderWorldLast event. If other mod asserts that then their rendering will turn into gray.
This can also be caused by Baritone but the latest release doesn't include the fix.
cabaletta/baritone@918f009