### PR TITLE
Fixed Chams depth bug

### DIFF
--- a/src/main/java/com/gamesense/api/util/render/ChamsUtil.java
+++ b/src/main/java/com/gamesense/api/util/render/ChamsUtil.java
@@ -1,20 +1,10 @@
 package com.gamesense.api.util.render;
 
-import static org.lwjgl.opengl.GL11.GL_LINE_SMOOTH;
-import static org.lwjgl.opengl.GL11.GL_LINE_SMOOTH_HINT;
-import static org.lwjgl.opengl.GL11.GL_NICEST;
-import static org.lwjgl.opengl.GL11.glDisable;
-import static org.lwjgl.opengl.GL11.glEnable;
-import static org.lwjgl.opengl.GL11.glHint;
-import static org.lwjgl.opengl.GL11.glLineWidth;
-import static org.lwjgl.opengl.GL11.glPolygonMode;
-import static org.lwjgl.opengl.GL11.glPolygonOffset;
-
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
+
+import static org.lwjgl.opengl.GL11.*;
 
 /**
 	Thank to seppuku for the code that i can understand,
@@ -31,8 +21,6 @@ import net.minecraft.client.renderer.OpenGlHelper;
 public class ChamsUtil {
 
 	private static final Minecraft mc = Minecraft.getMinecraft();
-	private final static float units = 5300000.0f;
-	private final static float factor = 1.0f;
 
 	public static void createChamsPre() {
 		mc.getRenderManager().setRenderShadow(false);
@@ -40,8 +28,8 @@ public class ChamsUtil {
 		GlStateManager.pushMatrix();
 		GlStateManager.depthMask(true);
 		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
-		glEnable(GL11.GL_POLYGON_OFFSET_FILL);
-		glPolygonOffset(factor, -units);
+		glEnable(GL_POLYGON_OFFSET_FILL);
+		glDepthRange(0.0, 0.01);
 		GlStateManager.popMatrix();
 	}
 
@@ -50,8 +38,8 @@ public class ChamsUtil {
 		mc.getRenderManager().setRenderShadow(shadow);
 		GlStateManager.pushMatrix();
 		GlStateManager.depthMask(false);
-		glDisable(GL11.GL_POLYGON_OFFSET_FILL);
-		glPolygonOffset(factor, units);
+		glDisable(GL_POLYGON_OFFSET_FILL);
+		glDepthRange(0.0, 1.0);
 		GlStateManager.popMatrix();
 	}
 
@@ -60,9 +48,9 @@ public class ChamsUtil {
 		mc.getRenderManager().setRenderOutlines(false);
 		GlStateManager.pushMatrix();
 		GlStateManager.depthMask(true);
-		glEnable(GL11.GL_POLYGON_OFFSET_FILL);
-		glPolygonOffset(factor, -units);
-		glDisable(GL11.GL_TEXTURE_2D);
+		glEnable(GL_POLYGON_OFFSET_FILL);
+		glDepthRange(0.0, 0.01);
+		glDisable(GL_TEXTURE_2D);
 		if (!isPlayer) {
 			GlStateManager.enableBlendProfile(GlStateManager.Profile.TRANSPARENT_MODEL);
 		}
@@ -78,9 +66,9 @@ public class ChamsUtil {
 		if (!isPlayer) {
 			GlStateManager.disableBlendProfile(GlStateManager.Profile.TRANSPARENT_MODEL);
 		}
-		glDisable(GL11.GL_POLYGON_OFFSET_FILL);
-		glPolygonOffset(factor, units);
-		glEnable(GL11.GL_TEXTURE_2D);
+		glDisable(GL_POLYGON_OFFSET_FILL);
+		glDepthRange(0.0, 1.0);
+		glEnable(GL_TEXTURE_2D);
 		GlStateManager.popMatrix();
 	}
 
@@ -89,11 +77,11 @@ public class ChamsUtil {
 		mc.getRenderManager().setRenderOutlines(false);
 		GlStateManager.pushMatrix();
 		GlStateManager.depthMask(true);
-		glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_LINE);
-		glEnable(GL11.GL_POLYGON_OFFSET_LINE);
-		glPolygonOffset(factor, -units);
-		glDisable(GL11.GL_TEXTURE_2D);
-		glDisable(GL11.GL_LIGHTING);
+		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+		glEnable(GL_POLYGON_OFFSET_LINE);
+		glDepthRange(0.0, 0.01);
+		glDisable(GL_TEXTURE_2D);
+		glDisable(GL_LIGHTING);
 		glEnable(GL_LINE_SMOOTH);
 		glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
 		if (!isPlayer) {
@@ -112,11 +100,11 @@ public class ChamsUtil {
 		if (!isPlayer) {
 			GlStateManager.disableBlendProfile(GlStateManager.Profile.TRANSPARENT_MODEL);
 		}
-		glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_FILL);
-		glDisable(GL11.GL_POLYGON_OFFSET_LINE);
-		glPolygonOffset(factor, units);
-		glEnable(GL11.GL_TEXTURE_2D);
-		glEnable(GL11.GL_LIGHTING);
+		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+		glDisable(GL_POLYGON_OFFSET_LINE);
+		glDepthRange(0.0, 1.0);
+		glEnable(GL_TEXTURE_2D);
+		glEnable(GL_LIGHTING);
 		glDisable(GL_LINE_SMOOTH);
 		GlStateManager.popMatrix();
 	}


### PR DESCRIPTION
This fixes the bug that entity disappear at the screen edge when standing close to a block. By using [`glDepthRange()`](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthRange.xhtml) instead of [`glPolygonOffset()`](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPolygonOffset.xhtml)

Before:
![2021-02-18_15 52 22](https://user-images.githubusercontent.com/62033805/108420212-806b9500-7201-11eb-92ae-d9e7ce8fddaf.png)

After:
![2021-02-18_15 50 37](https://user-images.githubusercontent.com/62033805/108420228-85304900-7201-11eb-984e-351a0bf187ea.png)
